### PR TITLE
Casting Content-Length HTTP header to a size_t

### DIFF
--- a/src/OFHTTPClient.m
+++ b/src/OFHTTPClient.m
@@ -113,7 +113,7 @@ normalize_key(char *str_)
 		_hasContentLength = true;
 
 		@try {
-			_toRead = [contentLength decimalValue];
+			_toRead = (size_t)[contentLength decimalValue];
 		} @catch (OFInvalidFormatException *e) {
 			@throw [OFInvalidServerReplyException
 			    exceptionWithClass: [self class]];


### PR DESCRIPTION
The Content-Length header is interpreted as a numeric value from
its string representation on line 116 of `OFHTTPClient.m`. On 32 bit
architectures this is fine, however on 64 bit architectures, this
is a compilation error. It's an implicit conversion from a
`intmax_t` (`long long`) to a `size_t` (`unsigned long`).

My fix is to cast the value. I examined the usage of the variable
throughout the file, and have determined that a cast is safe and
consistent with the intent of its usage. A similar thing is done on
line 207 of the same file.
