### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ other place, you are most likely using a mirror.
      compatible to a certain degree. This means that a developer still needs to
      care about differences between frameworks if they want to be portable. The
      idea behind ObjFW is that a developer does not need to concern themselves
-     with portablility and making sure their code works with multiple
+     with portability and making sure their code works with multiple
      frameworks: Instead, if it works it ObjFW on one platform, they can
      reasonably expect it to also work with ObjFW on another platform. ObjFW
      behaving differently on different operating systems (unless inevitable


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "portablility" to "portability" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.